### PR TITLE
Update JSON type to json

### DIFF
--- a/credential-types.html.md.erb
+++ b/credential-types.html.md.erb
@@ -33,7 +33,7 @@ Example:
 json
   {
     "name": "/example/value",
-    "type": "value",
+    "type": "json",
     "value": {
       "key": 123,
       "key\_list": [ "val1", "val2", "val3" ],


### PR DESCRIPTION
In https://docs.pivotal.io/tiledev/credhub.html we can see listed as a type `json` but here we see `value` on both, value and JSON type.