### PR TITLE
Cross link credhub API documentation

### DIFF
--- a/credential-types.html.md.erb
+++ b/credential-types.html.md.erb
@@ -51,6 +51,8 @@ CredHub supports the following credential types:
   </tr>
 </table>
 
+Each credential type supports distinct parameters to customize the associated credential generation (e.g. password min lengths, specific characters to include, certificate fields, ...). Please refer to the [Credhub generate credential API endpoint](https://credhub-api.cfapps.io/#generate-credentials) for the full list of supported parameters.
+
 For every credential type, secret values are encrypted before storage. For instance, the private key of a certificate-type credential and the password of a user-type credential are encrypted before storage. For JSON and Value type credentials, the full contents are encrypted before storage.
 
 


### PR DESCRIPTION
Cross link credhub API documentation to detail supported parameters for each credential type.