### PR TITLE
Steps to add credhub uaa groups

### DIFF
--- a/setup-credhub-bosh.html.md.erb
+++ b/setup-credhub-bosh.html.md.erb
@@ -293,8 +293,10 @@ $ uaac user add OTHER-EXAMPLE-USER --emails email<span>@</span>example.com
   Password:  ********
   Verify password:  ********
   user account successfully added<br/>
+$ uaac group add credhub.read
 $ uaac member add credhub.read EXAMPLE-USER OTHER-EXAMPLE-USER
   success<br/>
+$ uaac group add credhub.write
 $ uaac member add credhub.write EXAMPLE-USER OTHER-EXAMPLE-USER
   success
 </pre>


### PR DESCRIPTION
When following the instructions, if the UAA doesn't have the credhub groups created, upon execution of uaac member command, the following error is given: CF::UAA::NotFound: CF::UAA::NotFound

Inspecting the groups by running uaac groups revealed the deployment doesn't have those groups created by default. So added the steps to create the uaa groups before trying to add members to them which seemed to fix the problem.