### PR TITLE
Refer to director's "config server" as a feature

### DIFF
--- a/setup-credhub-bosh.html.md.erb
+++ b/setup-credhub-bosh.html.md.erb
@@ -205,7 +205,7 @@ For the full list of CredHub properties and default values, read the <a href="ht
             secret: EXAMPLE-SECRET # <--- Replace with custom client secret
 </pre>
 
-<li>Enable the config server on the Director and configure it to utilize CredHub.</li>
+<li>Enable the config server feature of Director and configure it to utilize CredHub.</li>
 
 <pre>
     properties:


### PR DESCRIPTION
Avoids confusion about this introducing yet another server within director, and avoids ambiguity about the config-server.yml file in bosh-deployment.

Related to https://github.com/cloudfoundry/bosh-deployment/issues/325