### PR TITLE
Clarify the docs so that they do not imply that we have to use k8s to implement the plugin

### DIFF
--- a/kms-plugin.html.md.erb
+++ b/kms-plugin.html.md.erb
@@ -23,9 +23,9 @@ This topic describes how to connect CredHub to a third-party Key Management Serv
 
 CredHub ships with its own internal encryption. However, you may want to use the encryption provided by a KMS instead.
 
-In order to use a KMS, you must deploy a plugin with CredHub. CredHub consumes the Kubernetes API for KMS plugins. The interface definition is in the `protobuf` format. For more information, see [Language Guide (proto3)](https://developers.google.com/protocol-buffers/docs/proto3) in the Google Protocol Buffers documentation.
+In order to use a KMS, you must deploy a plugin with CredHub. CredHub uses plugins that implement the KMS provider interface whose definition is in the `protobuf` format. This interface comes from Kubernetes ([here](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/)), but it is not necessary to use Kubernetes when writing a plugin. For more information, see [Language Guide (proto3)](https://developers.google.com/protocol-buffers/docs/proto3) in the Google Protocol Buffers documentation.
 
-Any plugin that implements the Kubernetes API should be compatible with CredHub. Consult the documentation for your KMS provider to learn whether a plugin exists. 
+Any plugin that implements the KMS provider interface should be compatible with CredHub. Consult the documentation for your KMS provider to learn whether a plugin exists. 
 
 If a plugin exists for your KMS provider, skip to [Build a BOSH Release](#build-a-release). 
 


### PR DESCRIPTION
Signed-off-by: Sannidhi Jalukar <sjalukar@pivotal.io>