### PR TITLE
Fix encryption example for "internal" provider

### DIFF
--- a/setup-credhub-bosh.html.md.erb
+++ b/setup-credhub-bosh.html.md.erb
@@ -175,7 +175,8 @@ This method derives a 256-bit key from the provided encryption password and util
           type: internal
         keys:
         - provider_name: main
-          encryption_password: ((credhub-encryption-password))
+          key_properties:
+            encryption_password: ((credhub-encryption-password))
           active: true
     ...
 </pre>


### PR DESCRIPTION
* see here: https://github.com/pivotal-cf/credhub-release/blob/24bad0440014d7b5dacdaca275629f2609b40662/jobs/credhub/templates/validation_encryption.yml.erb#L62
* code changed with https://github.com/pivotal-cf/credhub-release/commit/c71e0efe80c1078b869f79d6ea1089dae077771c