### PR TITLE
Include information on maximum credential size

### DIFF
--- a/credential-types.html.md.erb
+++ b/credential-types.html.md.erb
@@ -51,7 +51,7 @@ CredHub supports the following credential types:
   </tr>
 </table>
 
-Each credential type supports distinct parameters for customizing how credentials are generated. These include minimum password lengths, required characters, and certificate fields. For more information, see [Generate Credentials](https://credhub-api.cfapps.io/#generate-credentials) in the CredHub API documentation.
+Each credential type supports distinct parameters for customizing how credentials are generated. These include minimum password lengths, required characters, and certificate fields. Credentials have a maximum size of 64 KB. For more information, see [Generate Credentials](https://credhub-api.cfapps.io/#generate-credentials) in the CredHub API documentation.
 
 For every credential type, secret values are encrypted before storage. For instance, the private key of a certificate-type credential and the password of a user-type credential are encrypted before storage. For JSON and Value type credentials, the full contents are encrypted before storage.
 


### PR DESCRIPTION
Credentials in CredHub have a size limit of 64 KB. We would like to make it clear to users that this limit exists.

Should this be merged to any other branches?
This change should be back ported to all supported versions (OpsMan versions 2.9, 2.8, 2.7)