### PR TITLE
Add link to doc for CredHub's "Authorization and Permissions" function

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -37,7 +37,7 @@ CredHub performs a number of different functions to help generate and protect th
 
 * Securing data for storage
 * Authentication
-* Authorization
+* [Authorization and Permissions](https://github.com/cloudfoundry-incubator/credhub/blob/main/docs/authorization-and-permissions.md)
 * Access and change logging
 * Data typing
 * Credential generation


### PR DESCRIPTION
- To make in-repo OSS docs about CredHub's permissions more discoverable

[[174322077](https://www.pivotaltracker.com/story/show/174322077)]

Which other branches should this be merged with (if any)?
