### PR TITLE
Remove doc about a CredHub feature that does not exist

### DIFF
--- a/credential-types.html.md.erb
+++ b/credential-types.html.md.erb
@@ -88,7 +88,7 @@ Similarly, the object could be translated into YAML format:
     -----END EXAMPLE RSA PRIVATE KEY------
 ```
 
-If you want to leverage a non-string typed credential, update your release to properly consume the new format. The following example shows how to configure a release to accept the certificate credential referenced above. It includes an example to instruct users on how to define the values if they are not using a CredHub credential.
+If you want to leverage a non-string typed credential, update your release to properly consume the new format. The following example shows how to configure a release to accept the certificate and password credential types referenced above. The sample Release Job Spec below includes an example to instruct users on how to define the values if they are not using a CredHub credential.
 
 ### Release Job Spec
 
@@ -112,6 +112,9 @@ properties:
           -----BEGIN EXAMPLE RSA PRIVATE KEY-----
           ...
           -----END EXAMPLE RSA PRIVATE KEY-----
+  admin-password:
+    description: "Admin password for the application"
+    example: nZaowPHTl0CQYVyYA0nV7ayHVulCBU3WTmwJKiZm
 ```
 
 ### Job Template ERB
@@ -121,62 +124,18 @@ erb
 api-ca=<%= p("demo.tls.ca") %>
 api-certificate=<%= p("demo.tls.certificate") %>
 api-private-key=<%= p("demo.tls.private_key") %>
+admin-password=<%= p("admin-password") %>
 ```
 
 ### Deployment Manifest
 
-```
----
-name: demo-deploy
-
-instance_groups:
-  properties:
-    demo:
-      tls: ((demo-tls))
-```
-
-Updating a release for other types is similar to the example above, being mindful of the key name for each value you wish to consume.
-
-
-## <a name='enable-auto-generation'></a> Enabling CredHub Automatic Generation in Releases
-
-CredHub and BOSH are integrated to automatically generate missing credential values on deployment. To enable automatic generation, the release or manifest requires the correct configuration.
-
-The sample below demonstrates how to configure a job release spec to provide generation parameters. When you provide details in a release spec, use attributes that do not vary per deployment, such as type and password attributes.
-
-### Release Job Spec
-
-```
----
-name: demo
-
-properties:
-  demo.admin_password:
-    description: "Password for admin user"
-    type: password
-    parameters:
-      length: 40
-
-  demo.tls:
-    description: "Certificate and private key for TLS connection to API"
-    type: certificate
-    parameters:
-      key_length: 4096
-```
-
-You can also define these generation parameters in the deployment itself, as shown in the example below. Use this for generation parameters that are deployment-specific, such as a certificate common name.
-
-### Deployment Manifest
+CredHub and BOSH are integrated to provide the option of generating the required credential values on deployment. You can define these generation parameters in the deployment manifest under the `variables` section, as shown in the example below.
 
 ```
 ---
 name: demo-deploy
 
 variables:
-- name: demo-password
-  type: password
-  options:
-    length: 40
 - name: demo-ca
   type: certificate
   options:
@@ -192,11 +151,18 @@ variables:
     - www.example.com
     extended_key_usage:
     - client_auth
+- name: admin-password
+  type: password
+  options:
+    length: 40
 
 instance_groups:
   properties:
     demo:
-      admin-password: ((demo-password))
       tls: ((demo-tls))
+      admin-password: ((demo-password))
 ```
+
+Updating a release for other types is similar to the example above, being mindful of the key name for each value you wish to consume.
+
 <% end %>


### PR DESCRIPTION
- Based on [conversation with the BOSH
team](https://cloudfoundry.slack.com/archives/C3EN0BFC0/p1629132208003100),
the ability to autogenerate credentials based onn the BOSH release job
spec file is not an implemented feature.
- It seems like the doc around this non-existing feature was copied
from CredHub's in-repo docs: https://github.com/cloudfoundry-incubator/credhub/blob/main/docs
which we will also update to remove mentions of this feature.

Which other branches should this be merged with (if any)?
